### PR TITLE
Add Anthropic SDK LLM backend with tool use support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,14 +20,31 @@ OPENAI_TTS_SPEAKER=1
 # 再生速度（デフォルト: 1）
 OPENAI_TTS_SPEED=1
 
-# ===== LLM (OpenAI 互換 API) =====
+# ===== LLM =====
+# LLM バックエンド: "openai"（デフォルト）または "anthropic"
+# LLM_TYPE=openai
+
+# --- OpenAI 互換 API（LLM_TYPE=openai の場合）---
 # OpenAI 互換 LLM サーバーの URL（例: OpenClaw, Ollama）
 OPENAI_LLM_URL=
 # LLM サーバーの API キー（不要なら空のまま）
 OPENAI_LLM_API_KEY=
 # LLM モデル名
 OPENAI_LLM_MODEL=
-# LLM に渡すシステムプロンプト（未設定ならシステムメッセージなし）
+
+# --- Anthropic（LLM_TYPE=anthropic の場合）---
+# Anthropic API キー
+# ANTHROPIC_API_KEY=
+# モデル名（デフォルト: claude-haiku-4-5-20251001）
+# ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+# レスポンスの最大トークン数（デフォルト: 1024）
+# ANTHROPIC_MAX_TOKENS=1024
+# web search を有効にする（true/false、デフォルト: false）
+# ANTHROPIC_WEB_SEARCH=false
+# ツール呼び出しの最大ラウンドトリップ数（デフォルト: 5）
+# ANTHROPIC_MAX_TOOL_ROUNDS=5
+
+# LLM に渡すシステムプロンプト（共通、未設定ならデフォルト使用）
 # SYSTEM_PROMPT=これは音声通話での会話だ。応答は短く、口語体で話せ。
 
 # ===== 音声パイプライン =====

--- a/bot.ts
+++ b/bot.ts
@@ -395,7 +395,11 @@ export class DiscordBot {
       `TTS: ${this.config.tts.type} (${this.config.tts.config.baseUrl})`,
     );
     log.info(
-      `LLM: ${this.config.llm.type} (${this.config.llm.config.baseUrl})`,
+      `LLM: ${this.config.llm.type} (${
+        this.config.llm.type === "openai"
+          ? this.config.llm.config.baseUrl
+          : this.config.llm.config.model
+      })`,
     );
     log.info(
       `voice thresholds: minSpeechMs=${this.config.voice.minSpeechMs}, speechRms=${this.config.voice.speechRms}, interruptRms=${this.config.voice.interruptRms}`,

--- a/config.ts
+++ b/config.ts
@@ -11,6 +11,7 @@
 import type { WhisperSttConfig } from "./stt/whisper.ts";
 import type { OpenAiTtsConfig } from "./tts/openai.ts";
 import type { OpenAiLlmConfig } from "./llm/openai.ts";
+import type { AnthropicLlmConfig } from "./llm/anthropic.ts";
 import type { VoiceThresholds } from "./bot.ts";
 
 /**
@@ -26,7 +27,9 @@ export type TtsConfig = { type: "openai"; config: OpenAiTtsConfig };
 /**
  * LLM バックエンド設定。
  */
-export type LlmConfig = { type: "openai"; config: OpenAiLlmConfig };
+export type LlmConfig =
+  | { type: "openai"; config: OpenAiLlmConfig }
+  | { type: "anthropic"; config: AnthropicLlmConfig };
 
 /**
  * バリデーション済みのアプリケーション設定。
@@ -61,6 +64,43 @@ export interface Config {
    * 言語モデルバックエンド設定。
    */
   llm: LlmConfig;
+}
+
+/**
+ * LLM_TYPE 環境変数に基づいて LLM 設定を構築する。
+ * 未指定または "openai" なら OpenAI 互換、"anthropic" なら Anthropic SDK を使用する。
+ */
+function buildLlmConfig(): LlmConfig {
+  const llmType = Deno.env.get("LLM_TYPE") ?? "openai";
+
+  switch (llmType) {
+    case "anthropic":
+      return {
+        type: "anthropic",
+        config: {
+          apiKey: Deno.env.get("ANTHROPIC_API_KEY"),
+          model: Deno.env.get("ANTHROPIC_MODEL") ?? "claude-haiku-4-5-20251001",
+          systemPrompt: Deno.env.get("SYSTEM_PROMPT"),
+          maxTokens: Number(Deno.env.get("ANTHROPIC_MAX_TOKENS") ?? "1024"),
+          webSearch: Deno.env.get("ANTHROPIC_WEB_SEARCH") === "true",
+          maxToolRounds: Number(
+            Deno.env.get("ANTHROPIC_MAX_TOOL_ROUNDS") ?? "5",
+          ),
+        },
+      };
+    case "openai":
+      return {
+        type: "openai",
+        config: {
+          baseUrl: Deno.env.get("OPENAI_LLM_URL") ?? "",
+          apiKey: Deno.env.get("OPENAI_LLM_API_KEY"),
+          model: Deno.env.get("OPENAI_LLM_MODEL") ?? "",
+          systemPrompt: Deno.env.get("SYSTEM_PROMPT"),
+        },
+      };
+    default:
+      throw new Error(`未対応の LLM_TYPE: ${llmType}`);
+  }
 }
 
 /**
@@ -103,14 +143,6 @@ export function loadConfig(): Config {
         speed: Number(Deno.env.get("OPENAI_TTS_SPEED") ?? "1"),
       },
     },
-    llm: {
-      type: "openai",
-      config: {
-        baseUrl: Deno.env.get("OPENAI_LLM_URL") ?? "",
-        apiKey: Deno.env.get("OPENAI_LLM_API_KEY"),
-        model: Deno.env.get("OPENAI_LLM_MODEL") ?? "",
-        systemPrompt: Deno.env.get("SYSTEM_PROMPT"),
-      },
-    },
+    llm: buildLlmConfig(),
   };
 }

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,8 @@
     "proseWrap": "preserve"
   },
   "imports": {
+    "@anthropic-ai/sdk": "npm:@anthropic-ai/sdk@latest",
+    "@anthropic-ai/sdk/": "npm:/@anthropic-ai/sdk@latest/",
     "@discordjs/voice": "npm:@discordjs/voice@0.19.1",
     "@openai/openai": "jsr:@openai/openai@^6.26.0",
     "@snazzah/davey": "npm:@snazzah/davey@^0.1.10",

--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/dotenv@~0.225.6": "0.225.6",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "npm:@anthropic-ai/sdk@latest": "0.78.0_zod@3.25.76",
     "npm:@discordjs/voice@0.19.1": "0.19.1_opusscript@0.1.1",
     "npm:@snazzah/davey@~0.1.10": "0.1.10",
     "npm:discord.js@^14.25.1": "14.25.1",
@@ -32,6 +33,20 @@
     }
   },
   "npm": {
+    "@anthropic-ai/sdk@0.78.0_zod@3.25.76": {
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "dependencies": [
+        "json-schema-to-ts",
+        "zod"
+      ],
+      "optionalPeers": [
+        "zod"
+      ],
+      "bin": true
+    },
+    "@babel/runtime@7.28.6": {
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
+    },
     "@discordjs/builders@1.13.1": {
       "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
       "dependencies": [
@@ -277,6 +292,13 @@
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "json-schema-to-ts@3.1.1": {
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": [
+        "@babel/runtime",
+        "ts-algebra"
+      ]
+    },
     "lodash.snakecase@4.1.1": {
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
@@ -297,6 +319,9 @@
       "optionalPeers": [
         "opusscript"
       ]
+    },
+    "ts-algebra@2.0.0": {
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
     "ts-mixer@6.0.4": {
       "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
@@ -322,6 +347,7 @@
       "jsr:@openai/openai@^6.26.0",
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/dotenv@~0.225.6",
+      "npm:@anthropic-ai/sdk@latest",
       "npm:@discordjs/voice@0.19.1",
       "npm:@snazzah/davey@~0.1.10",
       "npm:discord.js@^14.25.1",

--- a/llm/anthropic.ts
+++ b/llm/anthropic.ts
@@ -1,0 +1,268 @@
+/**
+ * Anthropic SDK を直接使った LLM 実装。
+ *
+ * `@anthropic-ai/sdk` で Claude API に接続する。
+ * tool use（web search + カスタムツール）に対応し、
+ * ツール呼び出しのマルチターンループを chat() 内部で完結させる。
+ * MAX_HISTORY ターン分のローリング会話履歴を保持する。
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type {
+  MessageParam,
+  Tool,
+  ToolResultBlockParam,
+  ToolUseBlock,
+} from "@anthropic-ai/sdk/resources/messages";
+import { createLogger } from "../logger.ts";
+import type { LanguageModel } from "./types.ts";
+
+const log = createLogger("llm:anthropic");
+
+/**
+ * 保持するユーザー＋アシスタントのターンペア数の上限。
+ */
+const MAX_HISTORY = 20;
+
+/**
+ * カスタムツールの実行関数。
+ * ツール入力を受け取り、結果文字列を返す。
+ */
+export type ToolExecutor = (
+  input: Record<string, unknown>,
+) => Promise<string>;
+
+/**
+ * web search のユーザー位置情報。
+ */
+export interface WebSearchUserLocation {
+  type: "approximate";
+  city?: string;
+  region?: string;
+  country?: string;
+  timezone?: string;
+}
+
+/**
+ * web search の設定。
+ */
+export interface WebSearchConfig {
+  /** web search の最大使用回数。 */
+  maxUses?: number;
+  /** ユーザー位置情報。 */
+  userLocation?: WebSearchUserLocation;
+}
+
+/**
+ * AnthropicLlm のコンストラクタ設定。
+ */
+export interface AnthropicLlmConfig {
+  /**
+   * API キー。未指定なら ANTHROPIC_API_KEY 環境変数を使用する。
+   */
+  apiKey?: string;
+
+  /**
+   * 使用するモデル名。
+   */
+  model: string;
+
+  /**
+   * LLM に渡すシステムプロンプト。未指定ならデフォルトを使用する。
+   */
+  systemPrompt?: string;
+
+  /**
+   * レスポンスの最大トークン数。
+   */
+  maxTokens?: number;
+
+  /**
+   * Anthropic サーバーサイドの web search を有効にする。
+   * true で既定設定、オブジェクトで詳細設定。
+   */
+  webSearch?: boolean | WebSearchConfig;
+
+  /**
+   * クライアントサイドで実行するカスタムツール定義。
+   */
+  customTools?: Tool[];
+
+  /**
+   * カスタムツールの実行関数マップ。キーはツール名。
+   */
+  customToolExecutors?: Record<string, ToolExecutor>;
+
+  /**
+   * ツール呼び出しの最大ラウンドトリップ数。
+   */
+  maxToolRounds?: number;
+}
+
+/**
+ * Anthropic SDK 経由の言語モデル。
+ *
+ * 会話履歴はメモリ上に保持し、MAX_HISTORY * 2 メッセージを
+ * 超えると古いものから自動的に切り捨てる。
+ * tool use のループは chat() 内部で完結する。
+ */
+export class AnthropicLlm implements LanguageModel {
+  private readonly client: Anthropic;
+  private readonly model: string;
+  private readonly system: string;
+  private readonly maxTokens: number;
+  private readonly tools: (Tool | Record<string, unknown>)[];
+  private readonly customToolExecutors: Record<string, ToolExecutor>;
+  private readonly maxToolRounds: number;
+  private readonly history: MessageParam[] = [];
+
+  constructor(config: AnthropicLlmConfig) {
+    this.client = new Anthropic({
+      apiKey: config.apiKey,
+    });
+    this.model = config.model;
+    this.system = config.systemPrompt ??
+      "あなたは音声会話アシスタントです。簡潔に回答してください。";
+    this.maxTokens = config.maxTokens ?? 1024;
+    this.customToolExecutors = config.customToolExecutors ?? {};
+    this.maxToolRounds = config.maxToolRounds ?? 5;
+
+    // ツール配列を構築する。
+    this.tools = [];
+
+    // Anthropic サーバーサイドの web search。
+    if (config.webSearch) {
+      const wsConfig = typeof config.webSearch === "object"
+        ? config.webSearch
+        : {};
+      const webSearchTool: Record<string, unknown> = {
+        type: "web_search_20250305",
+        name: "web_search",
+      };
+      if (wsConfig.maxUses) webSearchTool.max_uses = wsConfig.maxUses;
+      if (wsConfig.userLocation) {
+        webSearchTool.user_location = wsConfig.userLocation;
+      }
+      this.tools.push(webSearchTool);
+    }
+
+    // クライアントサイド実行のカスタムツール。
+    if (config.customTools) {
+      this.tools.push(...config.customTools);
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  async chat(userMessage: string): Promise<string> {
+    this.history.push({ role: "user", content: userMessage });
+
+    // 直近のターンのみ保持するよう履歴をトリミングする。
+    while (this.history.length > MAX_HISTORY * 2) {
+      this.history.shift();
+    }
+
+    try {
+      for (let round = 0; round <= this.maxToolRounds; round++) {
+        const response = await this.client.messages.create({
+          model: this.model,
+          max_tokens: this.maxTokens,
+          system: this.system,
+          tools: this.tools.length > 0 ? this.tools as Tool[] : undefined,
+          messages: this.history,
+        });
+
+        this.history.push({ role: "assistant", content: response.content });
+
+        // tool_use 以外の終了理由 → テキストを抽出して返す。
+        if (response.stop_reason !== "tool_use") {
+          return this.extractText(response.content);
+        }
+
+        // クライアントサイドの tool_use ブロックのみ解決が必要。
+        // server_tool_use（web_search 等）はレスポンスに結果が含まれている。
+        const clientToolUseBlocks = response.content.filter(
+          (b: Anthropic.ContentBlock): b is ToolUseBlock =>
+            b.type === "tool_use",
+        );
+
+        if (clientToolUseBlocks.length === 0) {
+          // サーバーサイドツールのみだった場合。
+          return this.extractText(response.content);
+        }
+
+        const toolResults = await this.resolveToolCalls(clientToolUseBlocks);
+        this.history.push({ role: "user", content: toolResults });
+      }
+
+      log.warn("tool use round limit reached");
+      return "";
+    } catch (e: unknown) {
+      log.error("API error:", e);
+      // 追加したユーザーメッセージを削除する — このターンは失敗した。
+      this.history.pop();
+      return "";
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  clearHistory(): void {
+    this.history.length = 0;
+    log.info("conversation history cleared");
+  }
+
+  /**
+   * レスポンスのコンテンツブロックからテキストを抽出する。
+   */
+  private extractText(
+    content: Anthropic.ContentBlock[],
+  ): string {
+    return content
+      .filter((b) => b.type === "text")
+      .map((b) => (b as { type: "text"; text: string }).text)
+      .join("");
+  }
+
+  /**
+   * クライアントサイドのツール呼び出しを実行し、結果を返す。
+   */
+  private resolveToolCalls(
+    blocks: ToolUseBlock[],
+  ): Promise<ToolResultBlockParam[]> {
+    return Promise.all(
+      blocks.map(async (block) => {
+        const executor = this.customToolExecutors[block.name];
+        if (!executor) {
+          log.warn(`unknown tool: ${block.name}`);
+          return {
+            type: "tool_result" as const,
+            tool_use_id: block.id,
+            content: `Error: unknown tool "${block.name}"`,
+            is_error: true,
+          };
+        }
+        try {
+          const result = await executor(
+            block.input as Record<string, unknown>,
+          );
+          return {
+            type: "tool_result" as const,
+            tool_use_id: block.id,
+            content: result,
+          };
+        } catch (e) {
+          log.error(`tool "${block.name}" error:`, e);
+          return {
+            type: "tool_result" as const,
+            tool_use_id: block.id,
+            content: `Error: ${e instanceof Error ? e.message : String(e)}`,
+            is_error: true,
+          };
+        }
+      }),
+    );
+  }
+}

--- a/services.ts
+++ b/services.ts
@@ -14,6 +14,8 @@ import type { LanguageModel } from "./llm/types.ts";
 import { WhisperStt } from "./stt/whisper.ts";
 import { OpenAiTts } from "./tts/openai.ts";
 import { OpenAiLlm } from "./llm/openai.ts";
+import { AnthropicLlm } from "./llm/anthropic.ts";
+import type { AnthropicLlmConfig } from "./llm/anthropic.ts";
 import { VoicePlayer } from "./audio/player.ts";
 
 /**
@@ -47,22 +49,33 @@ function createTts(config: Config["tts"]): TextToSpeech {
 }
 
 /**
- * Config.llm の type に基づいて LLM インスタンスを生成する。
+ * LLM 生成時に追加で渡すオプション。
+ * Anthropic の場合にカスタムツール等を注入するために使用する。
  */
-function createLlm(config: Config["llm"]): LanguageModel {
+export type LlmExtras = Partial<AnthropicLlmConfig>;
+
+function createLlm(
+  config: Config["llm"],
+  extras?: LlmExtras,
+): LanguageModel {
   switch (config.type) {
     case "openai":
       return new OpenAiLlm(config.config);
+    case "anthropic":
+      return new AnthropicLlm({ ...config.config, ...extras });
   }
 }
 
 /**
  * Config に基づいてサービスインスタンスを生成する。
  */
-export function createServices(config: Config): Services {
+export function createServices(
+  config: Config,
+  llmExtras?: LlmExtras,
+): Services {
   const stt = createStt(config.stt);
   const tts = createTts(config.tts);
-  const llm = createLlm(config.llm);
+  const llm = createLlm(config.llm, llmExtras);
   const voicePlayer = new VoicePlayer(tts);
 
   return { stt, tts, llm, voicePlayer };


### PR DESCRIPTION
## Summary

- Anthropic SDK (`@anthropic-ai/sdk`) を直接使った `AnthropicLlm` 実装を追加
- `LLM_TYPE` 環境変数で `"openai"` / `"anthropic"` を切り替え可能に
- `createServices()` に `LlmExtras` 引数を追加し、カスタムツール（`customTools` / `customToolExecutors`）を外部から注入可能に

Closes #1

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `llm/anthropic.ts` | 新規 — Anthropic SDK を使った `LanguageModel` 実装。tool use ループ内蔵 |
| `config.ts` | `LlmConfig` に `"anthropic"` union 追加、`buildLlmConfig()` で切り替え |
| `services.ts` | `createLlm` に `"anthropic"` ケース追加、`LlmExtras` で tool 注入 |
| `bot.ts` | LLM ログ出力を anthropic 対応に修正 |
| `deno.json` | `@anthropic-ai/sdk` を imports に追加 |
| `.env.example` | Anthropic 関連の環境変数を追記 |

## Test plan

- [x] `deno check **/*.ts` — 型チェック通過
- [x] `deno lint` — リント通過
- [x] `deno fmt --check` — フォーマット通過
- [x] `deno task test` — 全 46 テスト通過
- [x] `LLM_TYPE=anthropic` で実際に Claude API と通信できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)