### PR TITLE
Add Discord operation tools for OpenAI LLM backend

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -47,6 +47,8 @@ import {
   createDiscordToolExecutors,
   discordTools,
 } from "./llm/anthropic/tools/discord.ts";
+import { OpenAiLlm } from "./llm/openai.ts";
+import { createDiscordTools } from "./llm/openai/tools/discord.ts";
 
 /**
  * /aivc スラッシュコマンドの定義。
@@ -470,14 +472,18 @@ export class DiscordBot {
       this.llm.setContext({ "discord.guild.name": guild.name });
     }
 
-    // Anthropic LLM の場合、Discord 操作ツールを注入する。
-    if (this.llm instanceof AnthropicLlm) {
+    // LLM バックエンドに応じて Discord 操作ツールを注入する。
+    if (this.llm instanceof OpenAiLlm) {
+      const tools = createDiscordTools(this.client, this.config.guildId);
+      this.llm.addTools(tools);
+      log.info("discord tools registered (openai)");
+    } else if (this.llm instanceof AnthropicLlm) {
       const executors = createDiscordToolExecutors(
         this.client,
         this.config.guildId,
       );
       this.llm.addTools(discordTools, executors);
-      log.info("discord tools registered");
+      log.info("discord tools registered (anthropic)");
     }
 
     // スラッシュコマンドをギルドに登録する。

--- a/deno.json
+++ b/deno.json
@@ -4,15 +4,17 @@
     "proseWrap": "preserve"
   },
   "imports": {
-    "@anthropic-ai/sdk": "npm:@anthropic-ai/sdk@latest",
-    "@anthropic-ai/sdk/": "npm:/@anthropic-ai/sdk@latest/",
+    "@anthropic-ai/sdk": "npm:@anthropic-ai/sdk@^0.78.0",
+    "@anthropic-ai/sdk/": "npm:/@anthropic-ai/sdk@^0.78.0/",
     "@discordjs/voice": "npm:@discordjs/voice@0.19.1",
-    "@openai/openai": "jsr:@openai/openai@^6.26.0",
+    "@openai/agents": "npm:@openai/agents@^0.7.1",
+    "@openai/openai": "npm:openai@^6.29.0",
     "@snazzah/davey": "npm:@snazzah/davey@^0.1.10",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.6",
     "discord.js": "npm:discord.js@^14.25.1",
-    "opusscript": "npm:opusscript@0.1.1"
+    "opusscript": "npm:opusscript@0.1.1",
+    "zod": "npm:zod@^4.3.6"
   },
   "tasks": {
     "start": "deno run -A main.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1,24 +1,19 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@openai/openai@^6.26.0": "6.26.0",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/dotenv@~0.225.6": "0.225.6",
     "jsr:@std/internal@^1.0.12": "1.0.12",
-    "npm:@anthropic-ai/sdk@latest": "0.78.0_zod@3.25.76",
+    "npm:@anthropic-ai/sdk@0.78": "0.78.0_zod@4.3.6",
     "npm:@discordjs/voice@0.19.1": "0.19.1_opusscript@0.1.1",
+    "npm:@openai/agents@~0.7.1": "0.7.1_zod@4.3.6",
     "npm:@snazzah/davey@~0.1.10": "0.1.10",
     "npm:discord.js@^14.25.1": "14.25.1",
+    "npm:openai@^6.29.0": "6.29.0_ws@8.19.0_zod@4.3.6",
     "npm:opusscript@0.1.1": "0.1.1",
-    "npm:zod@3": "3.25.76"
+    "npm:zod@^4.3.6": "4.3.6"
   },
   "jsr": {
-    "@openai/openai@6.26.0": {
-      "integrity": "9da9b30d91a8044b9f212c3a5a936dc5d49c180215cf2ee06dcdbf9261783da9",
-      "dependencies": [
-        "npm:zod"
-      ]
-    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
@@ -33,7 +28,7 @@
     }
   },
   "npm": {
-    "@anthropic-ai/sdk@0.78.0_zod@3.25.76": {
+    "@anthropic-ai/sdk@0.78.0_zod@4.3.6": {
       "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
       "dependencies": [
         "json-schema-to-ts",
@@ -135,12 +130,84 @@
         "tslib"
       ]
     },
+    "@hono/node-server@1.19.11_hono@4.12.7": {
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "dependencies": [
+        "hono"
+      ]
+    },
+    "@modelcontextprotocol/sdk@1.27.1_zod@4.3.6": {
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "dependencies": [
+        "@hono/node-server",
+        "ajv",
+        "ajv-formats",
+        "content-type",
+        "cors",
+        "cross-spawn",
+        "eventsource",
+        "eventsource-parser",
+        "express",
+        "express-rate-limit",
+        "hono",
+        "jose",
+        "json-schema-typed",
+        "pkce-challenge",
+        "raw-body",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
     "@napi-rs/wasm-runtime@1.1.1": {
       "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
       "dependencies": [
         "@emnapi/core",
         "@emnapi/runtime",
         "@tybys/wasm-util"
+      ]
+    },
+    "@openai/agents-core@0.7.1_zod@4.3.6_ws@8.19.0": {
+      "integrity": "sha512-GdYK9g03t4UCTnsd+nA7/YjXj3lk2e2TaWbo9Vs1btkSlqOguJA8maVwadypBGAdDIvr2LUp/H8jbMP3rv5t5Q==",
+      "dependencies": [
+        "debug",
+        "openai",
+        "zod"
+      ],
+      "optionalDependencies": [
+        "@modelcontextprotocol/sdk"
+      ],
+      "optionalPeers": [
+        "zod"
+      ]
+    },
+    "@openai/agents-openai@0.7.1_zod@4.3.6": {
+      "integrity": "sha512-tYfT5bNmh1XVtpQ43QevcCHpXn2aaxq9D3jvHzuhMMJIThMOtuck/ZoS+axyeXhR/4m8UfDEuehDFeYspSfxDg==",
+      "dependencies": [
+        "@openai/agents-core",
+        "debug",
+        "openai",
+        "zod"
+      ]
+    },
+    "@openai/agents-realtime@0.7.1_zod@4.3.6": {
+      "integrity": "sha512-CNDvQe1fZqoiuhFjxAXFaV2xQoQKNmm8QQD2YzS7uiOE3oOFrAwBySzBDx/BLdt5Xg7NvshNkwsGBru2rytVYw==",
+      "dependencies": [
+        "@openai/agents-core",
+        "@types/ws",
+        "debug",
+        "ws",
+        "zod"
+      ]
+    },
+    "@openai/agents@0.7.1_zod@4.3.6": {
+      "integrity": "sha512-c/t9h/ydtpPBcbfwQlk6wPZxGc+J01blrfxgDxSECD71gKPjXec/PfNTnPzuagD2Xc1mBGU8ZOKaqRrTz7+19g==",
+      "dependencies": [
+        "@openai/agents-core",
+        "@openai/agents-openai",
+        "@openai/agents-realtime",
+        "debug",
+        "openai",
+        "zod"
       ]
     },
     "@sapphire/async-queue@1.5.5": {
@@ -268,6 +335,98 @@
     "@vladfrangu/async_event_emitter@2.4.7": {
       "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="
     },
+    "accepts@2.0.0": {
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": [
+        "mime-types",
+        "negotiator"
+      ]
+    },
+    "ajv-formats@3.0.1_ajv@8.18.0": {
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": [
+        "ajv"
+      ],
+      "optionalPeers": [
+        "ajv"
+      ]
+    },
+    "ajv@8.18.0": {
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
+      ]
+    },
+    "body-parser@2.2.2": {
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dependencies": [
+        "bytes",
+        "content-type",
+        "debug",
+        "http-errors",
+        "iconv-lite",
+        "on-finished",
+        "qs",
+        "raw-body",
+        "type-is"
+      ]
+    },
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
+    },
+    "content-disposition@1.0.1": {
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "cookie-signature@1.2.2": {
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+    },
+    "cookie@0.7.2": {
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
+    "cors@2.8.6": {
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": [
+        "object-assign",
+        "vary"
+      ]
+    },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
+      ]
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
     "discord-api-types@0.38.42": {
       "integrity": "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ=="
     },
@@ -289,8 +448,183 @@
         "undici"
       ]
     },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "etag@1.8.1": {
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "eventsource-parser@3.0.6": {
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="
+    },
+    "eventsource@3.0.7": {
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": [
+        "eventsource-parser"
+      ]
+    },
+    "express-rate-limit@8.3.1_express@5.2.1": {
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "dependencies": [
+        "express",
+        "ip-address"
+      ]
+    },
+    "express@5.2.1": {
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": [
+        "accepts",
+        "body-parser",
+        "content-disposition",
+        "content-type",
+        "cookie",
+        "cookie-signature",
+        "debug",
+        "depd",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "finalhandler",
+        "fresh",
+        "http-errors",
+        "merge-descriptors",
+        "mime-types",
+        "on-finished",
+        "once",
+        "parseurl",
+        "proxy-addr",
+        "qs",
+        "range-parser",
+        "router",
+        "send",
+        "serve-static",
+        "statuses",
+        "type-is",
+        "vary"
+      ]
+    },
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri@3.1.0": {
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+    },
+    "finalhandler@2.1.1": {
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "on-finished",
+        "parseurl",
+        "statuses"
+      ]
+    },
+    "forwarded@0.2.0": {
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh@2.0.0": {
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "hono@4.12.7": {
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw=="
+    },
+    "http-errors@2.0.1": {
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": [
+        "depd",
+        "inherits",
+        "setprototypeof",
+        "statuses",
+        "toidentifier"
+      ]
+    },
+    "iconv-lite@0.7.2": {
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip-address@10.1.0": {
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+    },
+    "ipaddr.js@1.9.1": {
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-promise@4.0.0": {
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jose@6.2.1": {
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="
     },
     "json-schema-to-ts@3.1.1": {
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
@@ -298,6 +632,12 @@
         "@babel/runtime",
         "ts-algebra"
       ]
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "json-schema-typed@8.0.2": {
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "lodash.snakecase@4.1.1": {
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
@@ -308,8 +648,74 @@
     "magic-bytes.js@1.13.0": {
       "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="
     },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "merge-descriptors@2.0.0": {
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
+    },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
+    "mime-types@3.0.2": {
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "negotiator@1.0.0": {
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": [
+        "ee-first"
+      ]
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
+    },
+    "openai@6.29.0_ws@8.19.0_zod@4.3.6": {
+      "integrity": "sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==",
+      "dependencies": [
+        "ws",
+        "zod"
+      ],
+      "optionalPeers": [
+        "ws",
+        "zod"
+      ],
+      "bin": true
+    },
     "opusscript@0.1.1": {
       "integrity": "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA=="
+    },
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-to-regexp@8.3.0": {
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="
+    },
+    "pkce-challenge@5.0.1": {
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
     },
     "prism-media@1.3.5_opusscript@0.1.1": {
       "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
@@ -320,6 +726,126 @@
         "opusscript"
       ]
     },
+    "proxy-addr@2.0.7": {
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": [
+        "forwarded",
+        "ipaddr.js"
+      ]
+    },
+    "qs@6.15.0": {
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dependencies": [
+        "side-channel"
+      ]
+    },
+    "range-parser@1.2.1": {
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body@3.0.2": {
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": [
+        "bytes",
+        "http-errors",
+        "iconv-lite",
+        "unpipe"
+      ]
+    },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "router@2.2.0": {
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": [
+        "debug",
+        "depd",
+        "is-promise",
+        "parseurl",
+        "path-to-regexp"
+      ]
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send@1.2.1": {
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "fresh",
+        "http-errors",
+        "mime-types",
+        "ms",
+        "on-finished",
+        "range-parser",
+        "statuses"
+      ]
+    },
+    "serve-static@2.2.1": {
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": [
+        "encodeurl",
+        "escape-html",
+        "parseurl",
+        "send"
+      ]
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "side-channel-list@1.0.0": {
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect"
+      ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.0": {
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
+      ]
+    },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+    },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
     "ts-algebra@2.0.0": {
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
@@ -329,29 +855,61 @@
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": [
+        "content-type",
+        "media-typer",
+        "mime-types"
+      ]
+    },
     "undici-types@7.18.2": {
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
     },
     "undici@6.21.3": {
       "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="
     },
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ],
+      "bin": true
+    },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "ws@8.19.0": {
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="
     },
-    "zod@3.25.76": {
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    "zod-to-json-schema@3.25.1_zod@4.3.6": {
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dependencies": [
+        "zod"
+      ]
+    },
+    "zod@4.3.6": {
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@openai/openai@^6.26.0",
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/dotenv@~0.225.6",
-      "npm:@anthropic-ai/sdk@latest",
+      "npm:@anthropic-ai/sdk@0.78",
       "npm:@discordjs/voice@0.19.1",
+      "npm:@openai/agents@~0.7.1",
       "npm:@snazzah/davey@~0.1.10",
       "npm:discord.js@^14.25.1",
-      "npm:opusscript@0.1.1"
+      "npm:openai@^6.29.0",
+      "npm:opusscript@0.1.1",
+      "npm:zod@^4.3.6"
     ]
   }
 }

--- a/llm/openai.test.ts
+++ b/llm/openai.test.ts
@@ -1,30 +1,27 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { OpenAiLlm } from "./openai.ts";
 
 type FetchArgs = { url: string; init?: RequestInit };
 
-// 毎回新しい Response を返す（Response body は一度しか消費できないため）。
-function captureFetch(
-  responseFactory: () => Response,
-): { calls: FetchArgs[]; restore: () => void } {
-  const calls: FetchArgs[] = [];
-  const original = globalThis.fetch;
-  globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
-    calls.push({ url: url.toString(), init });
-    return Promise.resolve(responseFactory());
-  }) as typeof fetch;
-  return {
-    calls,
-    restore: () => {
-      globalThis.fetch = original;
-    },
-  };
-}
-
-function okResponse(content: string): () => Response {
+/**
+ * Responses API 形式のモックレスポンスを生成する。
+ * Agents SDK は内部で `/v1/responses` エンドポイントを使用する。
+ */
+function responsesApiOk(text: string): () => Response {
   return () =>
     new Response(
-      JSON.stringify({ choices: [{ message: { content } }] }),
+      JSON.stringify({
+        id: "resp_test",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text }],
+          },
+        ],
+      }),
       {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -36,238 +33,183 @@ function errResponse(): () => Response {
   return () => new Response("error", { status: 500 });
 }
 
+/**
+ * 呼び出し履歴を記録するモック fetch を生成する。
+ * OpenAI クライアントの `fetch` オプションに直接渡す。
+ */
+function createMockFetch(
+  responseFactory: () => Response,
+): { calls: FetchArgs[]; fetch: typeof globalThis.fetch } {
+  const calls: FetchArgs[] = [];
+  const mockFetch = ((
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    calls.push({ url: url.toString(), init });
+    return Promise.resolve(responseFactory());
+  }) as typeof globalThis.fetch;
+  return { calls, fetch: mockFetch };
+}
+
+/**
+ * 複数のレスポンスを順番に返すモック fetch を生成する。
+ * SDK のリトライにも対応するため、エラーレスポンスは連続で返す。
+ */
+function createSequentialMockFetch(
+  factories: (() => Response)[],
+): { calls: FetchArgs[]; fetch: typeof globalThis.fetch } {
+  const calls: FetchArgs[] = [];
+  let index = 0;
+  const mockFetch = ((
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    calls.push({ url: url.toString(), init });
+    // 最後のファクトリを使い回す（配列外参照を防ぐ）。
+    const factory = index < factories.length
+      ? factories[index++]
+      : factories[factories.length - 1];
+    return Promise.resolve(factory());
+  }) as typeof globalThis.fetch;
+  return { calls, fetch: mockFetch };
+}
+
 Deno.test("OpenAiLlm.chat: アシスタントの返答を返すこと", async () => {
-  const { calls, restore } = captureFetch(okResponse("こんにちは"));
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    assertEquals(await llm.chat("やあ"), "こんにちは");
-    assertEquals(calls.length, 1);
-  } finally {
-    restore();
-  }
+  const { calls, fetch } = createMockFetch(responsesApiOk("こんにちは"));
+  const llm = new OpenAiLlm({
+    baseUrl: "http://localhost:18789",
+    model: "test-model",
+    fetch,
+  });
+  assertEquals(await llm.chat("やあ"), "こんにちは");
+  assertEquals(calls.length, 1);
 });
 
 Deno.test("OpenAiLlm.chat: API キーがある場合に Authorization ヘッダを送信すること", async () => {
-  const { calls, restore } = captureFetch(okResponse("ok"));
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      apiKey: "secret-token",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    await llm.chat("test");
-    const headers = new Headers(calls[0].init?.headers as HeadersInit);
-    assertEquals(headers.get("Authorization"), "Bearer secret-token");
-  } finally {
-    restore();
-  }
-});
-
-Deno.test("OpenAiLlm.chat: 会話履歴が蓄積されること", async () => {
-  const { calls, restore } = captureFetch(okResponse("返答"));
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    await llm.chat("一発目");
-    await llm.chat("二発目");
-    const body = JSON.parse(calls[1].init?.body as string);
-    // systemPrompt 未指定なので user + assistant + user のみ
-    assertEquals(
-      body.messages.map((m: { role: string }) => m.role),
-      ["user", "assistant", "user"],
-    );
-  } finally {
-    restore();
-  }
+  const { calls, fetch } = createMockFetch(responsesApiOk("ok"));
+  const llm = new OpenAiLlm({
+    baseUrl: "http://localhost:18789",
+    apiKey: "secret-token",
+    model: "test-model",
+    fetch,
+  });
+  await llm.chat("test");
+  const headers = new Headers(calls[0].init?.headers as HeadersInit);
+  assertEquals(headers.get("Authorization"), "Bearer secret-token");
 });
 
 Deno.test("OpenAiLlm.chat: API エラー時に空文字列を返すこと", async () => {
-  const { restore } = captureFetch(errResponse());
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    assertEquals(await llm.chat("test"), "");
-  } finally {
-    restore();
-  }
+  const { fetch } = createMockFetch(errResponse());
+  const llm = new OpenAiLlm({
+    baseUrl: "http://localhost:18789",
+    model: "test-model",
+    fetch,
+  });
+  assertEquals(await llm.chat("test"), "");
 });
 
-Deno.test("OpenAiLlm.chat: 失敗したリクエストが履歴に追加されないこと", async () => {
-  let callCount = 0;
-  const factories = [errResponse(), okResponse("ok")];
-  const original = globalThis.fetch;
-  globalThis.fetch =
-    (() => Promise.resolve(factories[callCount++]())) as typeof fetch;
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    await llm.chat("失敗する");
-    await llm.chat("成功する");
-    assertEquals(callCount, 2);
-  } finally {
-    globalThis.fetch = original;
-  }
+Deno.test("OpenAiLlm.chat: 失敗したリクエストが履歴に影響しないこと", async () => {
+  // エラー時の呼び出し回数はリトライにより不定のため、
+  // 成功時のリクエストに失敗メッセージが含まれないことを検証する。
+  const { calls, fetch } = createSequentialMockFetch([
+    // SDK はリトライするため、エラーレスポンスを複数返す。
+    errResponse(),
+    errResponse(),
+    errResponse(),
+    // 2 回目の chat() で成功する。
+    responsesApiOk("ok"),
+  ]);
+
+  const llm = new OpenAiLlm({
+    baseUrl: "http://localhost:18789",
+    model: "test-model",
+    fetch,
+  });
+  await llm.chat("失敗する");
+  await llm.chat("成功する");
+
+  // 最後のリクエスト（成功した方）を取得する。
+  const lastCall = calls[calls.length - 1];
+  const body = JSON.parse(lastCall.init?.body as string);
+  const inputStr = JSON.stringify(body.input);
+  // 失敗したメッセージは履歴に残っていないこと。
+  assertEquals(inputStr.includes("失敗する"), false);
+  assertEquals(inputStr.includes("成功する"), true);
 });
 
-Deno.test("OpenAiLlm.chat: systemPrompt 指定時にシステムメッセージが最初に含まれること", async () => {
-  const { calls, restore } = captureFetch(okResponse("ok"));
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      systemPrompt: "テスト用プロンプト",
-      clientOptions: { maxRetries: 0 },
-    });
-    await llm.chat("hello");
-    const body = JSON.parse(calls[0].init?.body as string);
-    assertEquals(body.messages[0].role, "system");
-    assertEquals(body.messages[0].content, "テスト用プロンプト");
-    assertEquals(body.messages[1].role, "user");
-  } finally {
-    restore();
-  }
-});
-
-Deno.test("OpenAiLlm.chat: systemPrompt 未指定時にシステムメッセージが含まれないこと", async () => {
-  const { calls, restore } = captureFetch(okResponse("ok"));
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    await llm.chat("hello");
-    const body = JSON.parse(calls[0].init?.body as string);
-    assertEquals(body.messages[0].role, "user");
-    assertEquals(body.messages[0].content, "hello");
-  } finally {
-    restore();
-  }
-});
-
-Deno.test("OpenAiLlm.chat: 履歴が MAX_HISTORY*2 を超えた場合にトリミングされること", async () => {
-  const { calls, restore } = captureFetch(okResponse("reply"));
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    // MAX_HISTORY=20 なので 40 メッセージ（20 ターン）を超えるまで送る。
-    for (let i = 0; i < 21; i++) {
-      await llm.chat(`msg-${i}`);
-    }
-    const lastBody = JSON.parse(
-      calls[calls.length - 1].init?.body as string,
-    );
-    const nonSystem = lastBody.messages.filter(
-      (m: { role: string }) => m.role !== "system",
-    );
-    // 40 メッセージ以下であること（トリミング済み）
-    assertEquals(nonSystem.length <= 40, true);
-    // 最新のユーザーメッセージが含まれていること
-    const lastUserMsg = nonSystem[nonSystem.length - 1];
-    assertEquals(lastUserMsg.role, "user");
-    assertEquals(lastUserMsg.content, "msg-20");
-  } finally {
-    restore();
-  }
+Deno.test("OpenAiLlm.chat: systemPrompt 指定時にリクエストに含まれること", async () => {
+  const { calls, fetch } = createMockFetch(responsesApiOk("ok"));
+  const llm = new OpenAiLlm({
+    baseUrl: "http://localhost:18789",
+    model: "test-model",
+    systemPrompt: "テスト用プロンプト",
+    fetch,
+  });
+  await llm.chat("hello");
+  const body = JSON.parse(calls[0].init?.body as string);
+  assertEquals(typeof body.instructions, "string");
+  assertEquals(body.instructions.includes("テスト用プロンプト"), true);
 });
 
 Deno.test("OpenAiLlm.chat: 指定されたベース URL に POST されること", async () => {
-  const { calls, restore } = captureFetch(okResponse("ok"));
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://custom:1234",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    await llm.chat("test");
-    assertStringIncludes(
-      calls[0].url,
-      "http://custom:1234/v1/chat/completions",
-    );
-  } finally {
-    restore();
-  }
+  const { calls, fetch } = createMockFetch(responsesApiOk("ok"));
+  const llm = new OpenAiLlm({
+    baseUrl: "http://custom:1234",
+    model: "test-model",
+    fetch,
+  });
+  await llm.chat("test");
+  assertEquals(
+    calls[0].url.startsWith("http://custom:1234/v1/responses"),
+    true,
+  );
 });
 
 Deno.test("OpenAiLlm.chat: 指定したモデル名がリクエストに含まれること", async () => {
-  const { calls, restore } = captureFetch(okResponse("ok"));
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "custom-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    await llm.chat("test");
-    const body = JSON.parse(calls[0].init?.body as string);
-    assertEquals(body.model, "custom-model");
-  } finally {
-    restore();
-  }
+  const { calls, fetch } = createMockFetch(responsesApiOk("ok"));
+  const llm = new OpenAiLlm({
+    baseUrl: "http://localhost:18789",
+    model: "custom-model",
+    fetch,
+  });
+  await llm.chat("test");
+  const body = JSON.parse(calls[0].init?.body as string);
+  assertEquals(body.model, "custom-model");
 });
 
-Deno.test("OpenAiLlm.chat: choices が空の場合に空文字列を返すこと", async () => {
-  const { restore } = captureFetch(
-    () =>
-      new Response(JSON.stringify({ choices: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+Deno.test("OpenAiLlm.chat: 失敗後に再試行すると正しい結果が返ること", async () => {
+  const { fetch } = createSequentialMockFetch([
+    errResponse(),
+    errResponse(),
+    errResponse(),
+    responsesApiOk("成功"),
+  ]);
+
+  const llm = new OpenAiLlm({
+    baseUrl: "http://localhost:18789",
+    model: "test-model",
+    fetch,
+  });
+  const first = await llm.chat("これは失敗する");
+  assertEquals(first, "");
+  const second = await llm.chat("これは成功する");
+  assertEquals(second, "成功");
+});
+
+Deno.test("OpenAiLlm.clearHistory: 履歴がクリアされること", async () => {
+  const { calls, fetch } = createMockFetch(responsesApiOk("reply"));
+  const llm = new OpenAiLlm({
+    baseUrl: "http://localhost:18789",
+    model: "test-model",
+    fetch,
+  });
+  await llm.chat("一発目");
+  llm.clearHistory();
+  await llm.chat("二発目");
+  const body = JSON.parse(calls[1].init?.body as string);
+  // クリア後なので入力は「二発目」のみ。
+  const userInputs = (body.input as { role?: string }[]).filter(
+    (item) => item.role === "user",
   );
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    assertEquals(await llm.chat("test"), "");
-  } finally {
-    restore();
-  }
-});
-
-Deno.test("OpenAiLlm.chat: 失敗後に再試行すると履歴が正しいこと", async () => {
-  let callCount = 0;
-  const factories = [errResponse(), okResponse("成功")];
-  const original = globalThis.fetch;
-  const calls: FetchArgs[] = [];
-  globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
-    calls.push({ url: url.toString(), init });
-    return Promise.resolve(factories[callCount++]());
-  }) as typeof fetch;
-  try {
-    const llm = new OpenAiLlm({
-      baseUrl: "http://localhost:18789",
-      model: "test-model",
-      clientOptions: { maxRetries: 0 },
-    });
-    await llm.chat("これは失敗する");
-    const reply = await llm.chat("これは成功する");
-    assertEquals(reply, "成功");
-    // 2 回目のリクエストの履歴に失敗した 1 回目が含まれていないこと
-    const body = JSON.parse(calls[1].init?.body as string);
-    const userMsgs = body.messages.filter(
-      (m: { role: string }) => m.role === "user",
-    );
-    assertEquals(userMsgs.length, 1);
-    assertEquals(userMsgs[0].content, "これは成功する");
-  } finally {
-    globalThis.fetch = original;
-  }
+  assertEquals(userInputs.length, 1);
 });

--- a/llm/openai.ts
+++ b/llm/openai.ts
@@ -1,12 +1,15 @@
 /**
- * OpenAI 互換 API を使った LLM 実装。
+ * OpenAI Agents SDK を使った LLM 実装。
  *
- * OpenAI SDK の `chat.completions.create()` で通信する。
+ * `@openai/agents` の `Agent` / `run()` で通信する。
  * OpenClaw / Ollama など OpenAI 互換のエンドポイントならそのまま利用可能。
  * MAX_HISTORY ターン分のローリング会話履歴を保持する。
+ * `addTools()` で外部からツールを注入でき、Agent を再構築する。
  */
 
 import OpenAI from "@openai/openai";
+import { Agent, OpenAIResponsesModel, run, user } from "@openai/agents";
+import type { AgentInputItem, Tool } from "@openai/agents";
 import { createLogger } from "../logger.ts";
 import type { LanguageModel } from "./types.ts";
 import { replaceTemplateVariables } from "./template.ts";
@@ -39,39 +42,77 @@ export interface OpenAiLlmConfig {
    */
   model: string;
   /**
-   * OpenAI SDK に渡す追加オプション。
+   * カスタム fetch 関数。テストでのモック注入用。
    */
-  clientOptions?: Partial<ConstructorParameters<typeof OpenAI>[0]>;
+  fetch?: typeof globalThis.fetch;
 }
 
 /**
- * OpenAI 互換 API 経由の言語モデル。
+ * OpenAI Agents SDK 経由の言語モデル。
  *
  * 会話履歴はメモリ上に保持し、MAX_HISTORY * 2 メッセージを
  * 超えると古いものから自動的に切り捨てる。
+ * ツール呼び出しループは SDK 内部で自動的に完結する。
  */
 export class OpenAiLlm implements LanguageModel {
-  private readonly client: OpenAI;
-  private readonly model: string;
+  private readonly agentModel: OpenAIResponsesModel;
   private readonly systemPromptTemplate?: string;
   private context: Record<string, string> = {};
-  private readonly history: OpenAI.ChatCompletionMessageParam[] = [];
+  private agent: Agent;
+  private externalTools: Tool[] = [];
+  private history: AgentInputItem[] = [];
 
   constructor(config: OpenAiLlmConfig) {
-    this.client = new OpenAI({
+    // deno-lint-ignore no-explicit-any
+    const clientOptions: Record<string, any> = {
       baseURL: `${config.baseUrl}/v1`,
       apiKey: config.apiKey ?? "dummy",
-      ...config.clientOptions,
-    });
-    this.model = config.model;
+    };
+    if (config.fetch) {
+      clientOptions.fetch = config.fetch;
+    }
+    const client = new OpenAI(clientOptions);
+
+    // Agent ごとに OpenAI クライアントを紐付けるため
+    // グローバルの setDefaultOpenAIClient ではなく
+    // OpenAIResponsesModel を直接使う。
+    // deno-lint-ignore no-explicit-any
+    this.agentModel = new OpenAIResponsesModel(client as any, config.model);
     this.systemPromptTemplate = config.systemPrompt;
+    this.agent = this.buildAgent();
+  }
+
+  /**
+   * 現在の設定で Agent インスタンスを構築する。
+   */
+  private buildAgent(): Agent {
+    const instructions = this.systemPromptTemplate
+      ? replaceTemplateVariables(this.systemPromptTemplate, this.context)
+      : undefined;
+
+    return new Agent({
+      name: "openai-llm",
+      instructions: instructions ?? "",
+      model: this.agentModel,
+      tools: this.externalTools,
+    });
+  }
+
+  /**
+   * 外部からツールを追加し、Agent を再構築する。
+   *
+   * @param tools - 追加するツールの配列。
+   */
+  addTools(tools: Tool[]): void {
+    this.externalTools.push(...tools);
+    this.agent = this.buildAgent();
   }
 
   /**
    * @inheritdoc
    */
   async chat(userMessage: string): Promise<string> {
-    this.history.push({ role: "user", content: userMessage });
+    this.history.push(user(userMessage));
 
     // 直近のターンのみ保持するよう履歴をトリミングする。
     while (this.history.length > MAX_HISTORY * 2) {
@@ -79,23 +120,15 @@ export class OpenAiLlm implements LanguageModel {
     }
 
     try {
-      const messages: OpenAI.ChatCompletionMessageParam[] = [];
-      if (this.systemPromptTemplate) {
-        const systemPrompt = replaceTemplateVariables(
-          this.systemPromptTemplate,
-          this.context,
-        );
-        messages.push({ role: "system", content: systemPrompt });
-      }
-      messages.push(...this.history);
+      // システムプロンプトにコンテキスト変数を反映するため Agent を再構築する。
+      this.agent = this.buildAgent();
 
-      const completion = await this.client.chat.completions.create({
-        model: this.model,
-        messages,
-      });
+      const result = await run(this.agent, this.history);
+      const reply = result.finalOutput ?? "";
 
-      const reply = completion.choices?.[0]?.message?.content ?? "";
-      this.history.push({ role: "assistant", content: reply });
+      // SDK が返す履歴で上書きする（ツール呼び出し等も含まれる）。
+      this.history = [...result.history];
+
       return reply;
     } catch (e: unknown) {
       log.error("API error:", e);
@@ -109,7 +142,7 @@ export class OpenAiLlm implements LanguageModel {
    * @inheritdoc
    */
   clearHistory(): void {
-    this.history.length = 0;
+    this.history = [];
     log.info("conversation history cleared");
   }
 

--- a/llm/openai/tools/discord.ts
+++ b/llm/openai/tools/discord.ts
@@ -1,0 +1,216 @@
+/**
+ * Discord 操作ツール（OpenAI Agents SDK 版）。
+ *
+ * OpenAI Agents SDK の `tool()` + Zod スキーマ形式で
+ * Discord のギルド情報を取得・操作するツールを定義する。
+ * ロジックは Anthropic 版 (`llm/anthropic/tools/discord.ts`) と同等。
+ */
+
+import { Buffer } from "node:buffer";
+import type { Client } from "discord.js";
+import { ChannelType } from "discord.js";
+import { tool } from "@openai/agents";
+import type { Tool } from "@openai/agents";
+import { z } from "zod";
+import { createLogger } from "../../../logger.ts";
+
+const log = createLogger("llm:openai:tools:discord");
+
+/**
+ * 画像添付ファイルの最大バイト数（5 MB）。
+ * これを超える画像はスキップされる。
+ */
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+/**
+ * サポートする画像メディアタイプ。
+ */
+const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+/**
+ * Discord 操作ツール群を生成する。
+ *
+ * @param client - Discord.js クライアントインスタンス。
+ * @param guildId - 操作対象のギルド ID。
+ * @returns OpenAI Agents SDK のツール配列。
+ */
+export function createDiscordTools(
+  client: Client,
+  guildId: string,
+): Tool[] {
+  const listMembers = tool({
+    name: "discord_list_members",
+    description: "現在のギルド（Discord サーバー）のメンバー一覧を取得する。",
+    parameters: z.object({
+      limit: z.number().optional().describe(
+        "取得するメンバーの最大数。デフォルトは 100。",
+      ),
+    }),
+    execute: async (input) => {
+      const limit = input.limit ?? 100;
+      const guild = await client.guilds.fetch(guildId);
+      const members = await guild.members.list({ limit });
+
+      const result = members.map((m) => ({
+        id: m.id,
+        username: m.user.username,
+        displayName: m.displayName,
+        bot: m.user.bot,
+      }));
+
+      log.debug(`listed ${result.length} members`);
+      return JSON.stringify(result);
+    },
+  });
+
+  const listChannels = tool({
+    name: "discord_list_channels",
+    description: "現在のギルド（Discord サーバー）のチャンネル一覧を取得する。",
+    parameters: z.object({}),
+    execute: async () => {
+      const guild = await client.guilds.fetch(guildId);
+      const channels = await guild.channels.fetch();
+
+      const result = channels
+        .filter((ch) => ch !== null)
+        .map((ch) => ({
+          id: ch!.id,
+          name: ch!.name,
+          type: ChannelType[ch!.type],
+        }));
+
+      log.debug(`listed ${result.length} channels`);
+      return JSON.stringify(result);
+    },
+  });
+
+  const sendMessage = tool({
+    name: "discord_send_message",
+    description: "指定したチャンネルにテキストメッセージを送信する。",
+    parameters: z.object({
+      channelId: z.string().describe("送信先のチャンネル ID。"),
+      content: z.string().describe("送信するメッセージ内容。"),
+    }),
+    execute: async (input) => {
+      const channel = await client.channels.fetch(input.channelId);
+      if (!channel || !channel.isTextBased()) {
+        throw new Error(
+          `channel ${input.channelId} is not a text channel`,
+        );
+      }
+
+      if (!("send" in channel)) {
+        throw new Error(
+          `channel ${input.channelId} does not support sending`,
+        );
+      }
+
+      const msg = await channel.send(input.content);
+      log.debug(`sent message to ${input.channelId}: ${msg.id}`);
+      return JSON.stringify({ messageId: msg.id });
+    },
+  });
+
+  const getMessages = tool({
+    name: "discord_get_messages",
+    description: "指定したチャンネルの最新メッセージを取得する。",
+    parameters: z.object({
+      channelId: z.string().describe("メッセージを取得するチャンネル ID。"),
+      limit: z.number().optional().describe(
+        "取得するメッセージの最大数。デフォルトは 20。",
+      ),
+    }),
+    execute: async (input) => {
+      const limit = input.limit ?? 20;
+
+      const channel = await client.channels.fetch(input.channelId);
+      if (!channel || !channel.isTextBased()) {
+        throw new Error(
+          `channel ${input.channelId} is not a text channel`,
+        );
+      }
+
+      if (!("messages" in channel)) {
+        throw new Error(
+          `channel ${input.channelId} does not support messages`,
+        );
+      }
+
+      const messages = await channel.messages.fetch({ limit });
+      const result = messages.map((m) => ({
+        id: m.id,
+        author: {
+          id: m.author.id,
+          username: m.author.username,
+          displayName: m.member?.displayName ?? m.author.username,
+          bot: m.author.bot,
+        },
+        content: m.content,
+        attachments: m.attachments.map((a) => ({
+          id: a.id,
+          name: a.name,
+          contentType: a.contentType,
+          size: a.size,
+        })),
+        createdAt: m.createdAt.toISOString(),
+      }));
+
+      log.debug(`fetched ${result.length} messages from ${input.channelId}`);
+
+      // 画像添付ファイルを収集して base64 エンコードする。
+      // OpenAI Responses API の function_call_output は string のため、
+      // 画像 URL を添付情報として含める。
+      const imageUrls: { name: string; url: string }[] = [];
+      for (const msg of messages.values()) {
+        for (const attachment of msg.attachments.values()) {
+          if (!attachment.contentType) continue;
+          if (!SUPPORTED_IMAGE_TYPES.has(attachment.contentType)) continue;
+          if (attachment.size > MAX_IMAGE_BYTES) {
+            log.debug(
+              `skipping large image: ${attachment.name} (${attachment.size} bytes)`,
+            );
+            continue;
+          }
+
+          // base64 エンコードを試みるが、OpenAI の function output は
+          // string のみ対応のため、URL 文字列をフォールバックとして使う。
+          try {
+            const res = await fetch(attachment.url);
+            if (!res.ok) {
+              log.warn(
+                `failed to fetch image ${attachment.name}: ${res.status}`,
+              );
+              continue;
+            }
+            const buf = await res.arrayBuffer();
+            const base64 = Buffer.from(buf).toString("base64");
+            imageUrls.push({
+              name: attachment.name ?? "image",
+              url: `data:${attachment.contentType};base64,${base64}`,
+            });
+          } catch (e) {
+            log.warn(`failed to fetch image ${attachment.name}:`, e);
+            // フォールバック: Discord CDN の URL を使う。
+            imageUrls.push({
+              name: attachment.name ?? "image",
+              url: attachment.url,
+            });
+          }
+        }
+      }
+
+      if (imageUrls.length > 0) {
+        return JSON.stringify({ messages: result, images: imageUrls });
+      }
+
+      return JSON.stringify(result);
+    },
+  });
+
+  return [listMembers, listChannels, sendMessage, getMessages];
+}


### PR DESCRIPTION
## Summary

- OpenAI LLM バックエンドを OpenAI Agents SDK (`@openai/agents`) に移行
- `OpenAIResponsesModel` で Agent ごとに OpenAI クライアントを紐付け（グローバルシングルトン回避）
- Discord ツール 4 種を `tool()` + Zod スキーマで定義（`llm/openai/tools/discord.ts`）
- `bot.ts` で `OpenAiLlm` / `AnthropicLlm` に応じてツールを動的注入
- テストを Responses API モック形式に全面改修

## Test plan

- [ ] `deno fmt && deno lint && deno check **/*.ts` 通過
- [ ] `deno task test` 全テスト通過
- [ ] `LLM_TYPE=openai` で起動し、Discord ツールが動作することを確認
- [ ] ツール呼び出し（メンバー一覧、チャンネル一覧、メッセージ送受信）の動作確認

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)